### PR TITLE
RIBMP-0000: add drag & drop to delete and move items between sections

### DIFF
--- a/src/app/views/list/list.component.html
+++ b/src/app/views/list/list.component.html
@@ -1,55 +1,66 @@
-<div cdkDropListGroup>
-  <span
-    cdkDropList
-    (cdkDropListDropped)="dropTrash($event)"
-    class="material-icons trash-icon"
-    >restore_from_trash</span
-  >
-  <div class="container">
-    <div class="button-row">
-      <h1 class="title">{{ list?.title }}</h1>
-      <button (click)="openDialogAddGroup()" mat-icon-button>
-        <mat-icon>add</mat-icon>
-      </button>
-    </div>
-    <div class="row" cdkDropList id="section-cards">
-      <div
-        *ngFor="let section of list?.sections; let i = index"
-        class="col-6 col-md-4"
-        cdkDrag
-        [cdkDragData]="{ type: 'section', id: section.id }"
-        [cdkDragDisabled]="isUngroupedSection(section.title)"
+<span
+  cdkDropList
+  id="trash-list"
+  (cdkDropListDropped)="dropTrash($event)"
+  class="material-icons trash-icon"
+  >restore_from_trash</span
+>
+<div class="container">
+  <div class="button-row">
+    <h1 class="title">{{ list?.title }}</h1>
+    <button (click)="openDialogAddGroup()" mat-icon-button>
+      <mat-icon>add</mat-icon>
+    </button>
+  </div>
+  <div class="row">
+    <div
+      *ngFor="let section of list?.sections; let i = index"
+      class="col-6 col-md-4"
+      cdkDrag
+      [cdkDragData]="{ type: 'section', id: section.id }"
+      [cdkDragDisabled]="isUngroupedSection(section.title)"
+      cdkDropList
+      [cdkDropListConnectedTo]="['trash-list']"
+      [cdkDropListEnterPredicate]="noEnterPredicate"
+    >
+      <div class="section-header" [class.no-drag]="isUngroupedSection(section.title)" cdkDragHandle>
+        <mat-icon *ngIf="!isUngroupedSection(section.title)" class="drag-handle">drag_indicator</mat-icon>
+        <h2>{{ section.title }}</h2>
+      </div>
+      <mat-list
+        role="list"
+        cdkDropList
+        [cdkDropListData]="section.items"
+        [id]="'cdk-drop-list-section-' + section.id"
+        [cdkDropListConnectedTo]="getItemConnectedIds(section.id)"
+        (cdkDropListDropped)="dropItem($event)"
       >
-        <div class="section-header" [class.no-drag]="isUngroupedSection(section.title)" cdkDragHandle>
-          <mat-icon *ngIf="!isUngroupedSection(section.title)" class="drag-handle">drag_indicator</mat-icon>
-          <h2>{{ section.title }}</h2>
-        </div>
-        <mat-list role="list">
-          <mat-list-item *ngFor="let item of section.items">{{
-            item
-          }}</mat-list-item>
-        </mat-list>
-        <div class="add-item-row">
-          <input
-            #itemInput
-            type="text"
-            maxlength="40"
-            placeholder="New item..."
-            (keyup.enter)="
-              onAddItemToSection(section.id, itemInput.value);
-              itemInput.value = ''
-            "
-          />
-          <button
-            mat-icon-button
-            (click)="
-              onAddItemToSection(section.id, itemInput.value);
-              itemInput.value = ''
-            "
-          >
-            <mat-icon>add</mat-icon>
-          </button>
-        </div>
+        <mat-list-item
+          cdkDrag
+          [cdkDragData]="{ type: 'item', sectionId: section.id }"
+          *ngFor="let item of section.items"
+        >{{ item }}</mat-list-item>
+      </mat-list>
+      <div class="add-item-row">
+        <input
+          #itemInput
+          type="text"
+          maxlength="40"
+          placeholder="New item..."
+          (keyup.enter)="
+            onAddItemToSection(section.id, itemInput.value);
+            itemInput.value = ''
+          "
+        />
+        <button
+          mat-icon-button
+          (click)="
+            onAddItemToSection(section.id, itemInput.value);
+            itemInput.value = ''
+          "
+        >
+          <mat-icon>add</mat-icon>
+        </button>
       </div>
     </div>
   </div>

--- a/src/app/views/list/list.component.scss
+++ b/src/app/views/list/list.component.scss
@@ -54,6 +54,14 @@
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }
 
+mat-list-item[cdkDrag] {
+  cursor: grab;
+
+  &:active {
+    cursor: grabbing;
+  }
+}
+
 .trash-icon {
   position: fixed;
   bottom: 28px;

--- a/src/app/views/list/list.component.spec.ts
+++ b/src/app/views/list/list.component.spec.ts
@@ -134,23 +134,18 @@ describe('ListComponent', () => {
 
   // --- drag & drop setup ---
 
-  it('should have a cdkDropList on the section container', () => {
-    const sectionContainer = fixture.debugElement.query(By.css('#section-cards'));
-    expect(sectionContainer).toBeTruthy();
-    const dropList = sectionContainer.injector.get(CdkDropList, null);
-    expect(dropList).toBeTruthy();
-  });
-
-  it('should have a cdkDropList on the trash icon', () => {
+  it('should have a cdkDropList on the trash icon with explicit id', () => {
     const trashEl = fixture.debugElement.query(By.css('.trash-icon'));
     expect(trashEl).toBeTruthy();
     const dropList = trashEl.injector.get(CdkDropList, null);
     expect(dropList).toBeTruthy();
+    expect(dropList!.id).toBe('trash-list');
   });
 
-  it('should render sections as cdkDrag elements', () => {
+  it('should render sections and items as cdkDrag elements', () => {
+    // 3 sections + 4 items (2 in Packing + 2 in Electronics)
     const dragElements = fixture.debugElement.queryAll(By.css('[cdkDrag]'));
-    expect(dragElements.length).toBe(3);
+    expect(dragElements.length).toBe(7);
   });
 
   // --- ungrouped section ---
@@ -188,7 +183,7 @@ describe('ListComponent', () => {
     expect(mockListService.removeSectionFromList).toHaveBeenCalledWith('list1', 's1');
   });
 
-  it('should not remove section when drag data type is not section', () => {
+  it('should not remove section when drag data type is not section or item', () => {
     const event = {
       previousIndex: 0,
       previousContainer: { id: 'sections' },
@@ -199,6 +194,7 @@ describe('ListComponent', () => {
     component.dropTrash(event);
 
     expect(mockListService.removeSectionFromList).not.toHaveBeenCalled();
+    expect(mockListService.updateSectionItems).not.toHaveBeenCalled();
   });
 
   it('should not remove section when list is undefined', () => {
@@ -213,6 +209,102 @@ describe('ListComponent', () => {
     component.dropTrash(event);
 
     expect(mockListService.removeSectionFromList).not.toHaveBeenCalled();
+  });
+
+  // --- dropTrash for items ---
+
+  it('should remove an item when dragged to trash', () => {
+    const event = {
+      previousIndex: 0,
+      previousContainer: { id: 'cdk-drop-list-section-s1' },
+      container: { id: 'trash' },
+      item: { data: { type: 'item', sectionId: 's1' } },
+    } as unknown as CdkDragDrop<any>;
+
+    component.dropTrash(event);
+
+    expect(mockListService.updateSectionItems).toHaveBeenCalledWith(
+      'list1',
+      's1',
+      ['Tickets']
+    );
+  });
+
+  it('should remove the correct item by index when dragged to trash', () => {
+    const event = {
+      previousIndex: 1,
+      previousContainer: { id: 'cdk-drop-list-section-s2' },
+      container: { id: 'trash' },
+      item: { data: { type: 'item', sectionId: 's2' } },
+    } as unknown as CdkDragDrop<any>;
+
+    component.dropTrash(event);
+
+    expect(mockListService.updateSectionItems).toHaveBeenCalledWith(
+      'list1',
+      's2',
+      ['Phone']
+    );
+  });
+
+  it('should not remove item when list is undefined', () => {
+    component.list = undefined;
+    const event = {
+      previousIndex: 0,
+      previousContainer: { id: 'cdk-drop-list-section-s1' },
+      container: { id: 'trash' },
+      item: { data: { type: 'item', sectionId: 's1' } },
+    } as unknown as CdkDragDrop<any>;
+
+    component.dropTrash(event);
+
+    expect(mockListService.updateSectionItems).not.toHaveBeenCalled();
+  });
+
+  // --- dropItem (reorder / transfer between sections) ---
+
+  it('should reorder items within the same section', () => {
+    const containerData = component.list!.sections[1].items;
+    const event = {
+      previousIndex: 0,
+      currentIndex: 1,
+      previousContainer: { id: 'cdk-drop-list-section-s1', data: containerData },
+      container: { id: 'cdk-drop-list-section-s1', data: containerData },
+    } as unknown as CdkDragDrop<string[]>;
+
+    component.dropItem(event);
+
+    expect(mockListService.updateSectionItems).toHaveBeenCalledWith(
+      'list1',
+      's1',
+      ['Tickets', 'Passport']
+    );
+  });
+
+  it('should transfer an item between sections', () => {
+    const sourceData = component.list!.sections[1].items; // s1: Packing
+    const targetData = component.list!.sections[2].items; // s2: Electronics
+    const event = {
+      previousIndex: 0,
+      currentIndex: 1,
+      previousContainer: { id: 'cdk-drop-list-section-s1', data: sourceData },
+      container: { id: 'cdk-drop-list-section-s2', data: targetData },
+    } as unknown as CdkDragDrop<string[]>;
+
+    component.dropItem(event);
+
+    // Source section updated (item removed)
+    expect(mockListService.updateSectionItems).toHaveBeenCalledWith(
+      'list1',
+      's1',
+      ['Tickets']
+    );
+    // Target section updated (item added)
+    expect(mockListService.updateSectionItems).toHaveBeenCalledWith(
+      'list1',
+      's2',
+      ['Phone', 'Passport', 'Charger']
+    );
   });
 
   // --- recentlyDropped guard ---

--- a/src/app/views/list/list.component.ts
+++ b/src/app/views/list/list.component.ts
@@ -1,6 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
-import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
+import {
+  CdkDragDrop,
+  DragDropModule,
+  moveItemInArray,
+  transferArrayItem,
+} from '@angular/cdk/drag-drop';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { take } from 'rxjs/operators';
@@ -80,13 +85,70 @@ export class ListComponent implements OnInit {
   dropTrash(event: CdkDragDrop<any>): void {
     this.markRecentlyDropped();
     const dragData = event.item.data;
-    if (dragData?.type === 'section' && this.list) {
+    if (!this.list) return;
+
+    if (dragData?.type === 'section') {
       const section = this.list.sections.find((s) => s.id === dragData.id);
       if (section && this.isUngroupedSection(section.title)) return;
       this.listService
         .removeSectionFromList(this.list.id, dragData.id)
         .subscribe();
+      return;
     }
+
+    if (dragData?.type === 'item') {
+      const section = this.list.sections.find(
+        (s) => s.id === dragData.sectionId
+      );
+      if (section) {
+        section.items.splice(event.previousIndex, 1);
+        this.listService
+          .updateSectionItems(this.list.id, section.id, section.items)
+          .subscribe();
+      }
+    }
+  }
+
+  dropItem(event: CdkDragDrop<string[]>): void {
+    if (event.previousContainer === event.container) {
+      moveItemInArray(event.container.data, event.previousIndex, event.currentIndex);
+    } else {
+      transferArrayItem(
+        event.previousContainer.data,
+        event.container.data,
+        event.previousIndex,
+        event.currentIndex
+      );
+      const prevSectionId = this.resolveSectionId(event.previousContainer.id);
+      const prevSection = this.list?.sections.find((s) => s.id === prevSectionId);
+      if (prevSection && this.list) {
+        this.listService
+          .updateSectionItems(this.list.id, prevSection.id, prevSection.items)
+          .subscribe();
+      }
+    }
+
+    const sectionId = this.resolveSectionId(event.container.id);
+    const section = this.list?.sections.find((s) => s.id === sectionId);
+    if (section && this.list) {
+      this.listService
+        .updateSectionItems(this.list.id, section.id, section.items)
+        .subscribe();
+    }
+  }
+
+  noEnterPredicate = () => false;
+
+  getItemConnectedIds(sectionId: string): string[] {
+    if (!this.list) return ['trash-list'];
+    const otherIds = this.list.sections
+      .filter((s) => s.id !== sectionId)
+      .map((s) => 'cdk-drop-list-section-' + s.id);
+    return ['trash-list', ...otherIds];
+  }
+
+  private resolveSectionId(containerId: string): string {
+    return containerId.replace('cdk-drop-list-section-', '');
   }
 
   private markRecentlyDropped(): void {


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Configuration
- [ ] Test
- [ ] CI/CD

## Description

Extends the drag & drop UX in the list view to support item-level interactions:

- Items inside each section are now draggable (`cdkDrag`)
- Dragging an item to the trash icon removes it from its section (via `dropTrash`)
- Dragging an item to another section transfers it (via new `dropItem` method)
- Items can also be reordered within the same section via drag & drop
- Trash icon now has an explicit `id="trash-list"` for reliable CDK drop list targeting
- Added `grab`/`grabbing` cursor styles for draggable items

## Related Tickets & Documents

- RIBMP-0000 (no JIRA story linked)

## Test Plan

- Unit tests added for all new drag & drop scenarios:
  - Remove item by dragging to trash
  - Correct item removed by index
  - Guard against undefined list
  - Reorder items within same section
  - Transfer item between sections
- All existing drag & drop tests updated to reflect new structure

## Checklist

- [x] Code compiles without errors
- [x] Unit tests pass
- [x] Self-review completed
- [ ] No new SonarQube issues introduced